### PR TITLE
Fixes cross-origin asset loading, adds .no-hyphens

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed cross-origin asset loading, added .no-hyphens
+
 ## [1.3.1] - 2021-06-16
 
 ### Changed

--- a/assets/scripts/hyphenation.js
+++ b/assets/scripts/hyphenation.js
@@ -92,7 +92,11 @@ export default class Hyphenation {
                 elements.each( ( idx, node ) => {
                     const element = $( node );
 
-                    if ( typeof element.innerHTML === 'undefined' || element.innerHTML.length < 1 ) {
+                    if (
+                        typeof element.innerHTML === 'undefined' ||
+                        element.innerHTML.length < 1 ||
+                        element.hasClass( 'no-hyphens' )
+                    ) {
                         return;
                     }
 

--- a/assets/styles/base/_typography.scss
+++ b/assets/styles/base/_typography.scss
@@ -40,3 +40,7 @@ a {
 .has-line-height-tight {
     line-height: 1.1;
 }
+
+.no-hyphens {
+    hyphens: none !important;
+}

--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -35,14 +35,17 @@ class Constants implements Interfaces\Controller {
             define( 'DPT_ASSET_CACHE_URI', DPT_STYLESHEET_DIR . '/assets/dist' );
         }
 
+        // Returns /app/themes/{current theme} -- no need to reference other domains here.
+        $themes_root = wp_parse_url( \get_template_directory_uri(), PHP_URL_PATH );
+
         // Define the assets path.
         if ( ! defined( 'DPT_ASSETS_URI' ) ) {
-            define( 'DPT_ASSETS_URI', \get_template_directory_uri() . '/assets' );
+            define( 'DPT_ASSETS_URI', $themes_root . '/assets' );
         }
 
         // Define the assets dist path.
         if ( ! defined( 'DPT_ASSET_URI' ) ) {
-            define( 'DPT_ASSET_URI', \get_template_directory_uri() . '/assets/dist' );
+            define( 'DPT_ASSET_URI', $themes_root . '/assets/dist' );
         }
 
         // Set Polylang active state. Use this to check if Polylang plugin is active.

--- a/partials/layouts/layout-hero.dust
+++ b/partials/layouts/layout-hero.dust
@@ -24,7 +24,7 @@
                 <div class="column">
                     <div class="hero__box is-relative {box_classes|s}">
                         {?title}
-                            <h1 class="mt-0 h2">
+                            <h1 class="mt-0 h2 no-hyphens">
                                 {title|s}
                             </h1>
                         {/title}


### PR DESCRIPTION
## Description

- Loads shared assets now without domain information skipping CORS problems. 
- Adds `.no-hyphen` css class to disable hyphenation where applicable
- Adds `.no-hyphen` to hero `h1`

## Motivation and Context

- Some assets failed to load on other domains
- Header hyphenation looked "weird" (that's a technical term)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
