### PR TITLE
Upgrade deprecated hooks

### DIFF
--- a/lib/BlocksController.php
+++ b/lib/BlocksController.php
@@ -95,11 +95,11 @@ class BlocksController implements Interfaces\Controller {
      * fill the array with the block types that the theme supports.
      *
      * @param bool|array $allowed_blocks An empty array.
-     * @param \WP_Post   $post           The post resource data.
+     * @param \WP_Post   $context        The current block editor context.
      *
      * @return array An array of allowed block types.
      */
-    private function allowed_block_types( $allowed_blocks, $post ) {
+    private function allowed_block_types( $allowed_blocks, $context ) {
         $blocks = [
             'core/block'        => [],
             'core/template'     => [],
@@ -250,8 +250,8 @@ class BlocksController implements Interfaces\Controller {
         ];
 
         $allowed_blocks = [];
-        $post_type      = \get_post_type( $post );
-        $page_template  = \get_page_template_slug( $post->ID );
+        $post_type      = \get_post_type( $context->post->ID );
+        $page_template  = \get_page_template_slug( $context->post->ID );
 
         foreach ( $blocks as $block => $rules ) {
             if ( empty( $rules ) ) {

--- a/lib/BlocksController.php
+++ b/lib/BlocksController.php
@@ -32,7 +32,7 @@ class BlocksController implements Interfaces\Controller {
      */
     public function hooks() : void {
         \add_filter(
-            'allowed_block_types',
+            'allowed_block_types_all',
             \Closure::fromCallable( [ $this, 'allowed_block_types' ] ),
             10,
             2

--- a/lib/ThemeSupports.php
+++ b/lib/ThemeSupports.php
@@ -46,7 +46,7 @@ class ThemeSupports implements Interfaces\Controller {
         \add_theme_support( 'editor-font-sizes', [] );
 
         \add_filter(
-            'block_editor_settings',
+            'block_editor_settings_all',
             \Closure::fromCallable( [ $this, 'disable_drop_cap' ] )
         );
     }


### PR DESCRIPTION
## Description
Upgrade hooks deprecated in WP 5.8.

## Motivation and Context
Fixes deprecation notices in WP 5.8.