### PR TITLE
a11y: Prevent duplicate img ids

### DIFF
--- a/lib/DustPressController.php
+++ b/lib/DustPressController.php
@@ -38,6 +38,10 @@ class DustPressController implements Interfaces\Controller {
             'dustpress/pagination/data',
             \Closure::fromCallable( [ $this, 'disable_pagination_hellip_duplicate_link' ] )
         );
+        add_filter(
+            'dustpress/image/allowed_attributes',
+            \Closure::fromCallable( [ $this, 'disable_image_ids' ] )
+        );
     }
 
     /**
@@ -53,5 +57,18 @@ class DustPressController implements Interfaces\Controller {
         }
 
         return $data;
+    }
+
+    /**
+     * Remove id attribute from image output in order to prevent duplicate ids in site markup.
+     *
+     * @param array $allowed_attributes Allowed attributes.
+     *
+     * @return array
+     */
+    protected function disable_image_ids( $allowed_attributes ) : array {
+        unset( $allowed_attributes['id'] );
+
+        return $allowed_attributes;
     }
 }

--- a/lib/ThemeSupports.php
+++ b/lib/ThemeSupports.php
@@ -46,7 +46,7 @@ class ThemeSupports implements Interfaces\Controller {
         \add_theme_support( 'editor-font-sizes', [] );
 
         \add_filter(
-            'block_editor_settings',
+            'block_editor_settings_all',
             \Closure::fromCallable( [ $this, 'disable_drop_cap' ] )
         );
     }


### PR DESCRIPTION
## Description
Remove `<img>` id attribute from output in order to prevent duplicate ids in site markup.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)