### PR TITLE
Fixes type error: expected array, got bool

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - DR-2: misc appearance fixes and improvements #130
 - DR-3: misc appearance fixes and improvements #131
 - DR-4: misc appearance fixes and improvements #132
+- Fixes type error: expected array, got bool #138
 
 ## [1.7.0] - 2021-08-06
 

--- a/lib/ACF/Fields/AccordionFields.php
+++ b/lib/ACF/Fields/AccordionFields.php
@@ -89,6 +89,8 @@ class AccordionFields extends Field\Group {
             ->set_key( "${key}_sections" )
             ->set_name( 'sections' )
             ->set_layout( 'block' )
+            ->set_min( 1 )
+            ->set_required()
             ->set_button_label( $strings['sections']['button'] )
             ->set_instructions( $strings['sections']['instructions'] );
 

--- a/lib/Blocks/AccordionBlock.php
+++ b/lib/Blocks/AccordionBlock.php
@@ -72,6 +72,10 @@ class AccordionBlock extends BaseBlock {
      * @return array The block data.
      */
     public function filter_data( $data, $instance, $block, $content, $is_preview, $post_id ) : array { // phpcs:ignore
+        if ( ! is_array( $data ) ) {
+            $data = [];
+        }
+
         return apply_filters( 'tms/acf/block/' . self::KEY . '/data', $data );
     }
 }

--- a/lib/Formatters/AccordionFormatter.php
+++ b/lib/Formatters/AccordionFormatter.php
@@ -48,7 +48,7 @@ class AccordionFormatter implements \TMS\Theme\Base\Interfaces\Formatter {
             $section['section_content'] = $this->handle_layouts( $section['section_content'] );
 
             return $section;
-        }, $data['sections'] );
+        }, $data['sections'] ?? [] );
 
         return $data;
     }

--- a/lib/Traits/Components.php
+++ b/lib/Traits/Components.php
@@ -20,9 +20,9 @@ trait Components {
      * @return array
      */
     public function components() : array {
-        $content = get_field( 'components' );
+        $content = get_field( 'components' ) ?? [];
 
-        if ( empty( $content ) ) {
+        if ( empty( $content ) || ! is_array( $content ) ) {
             return [];
         }
 


### PR DESCRIPTION
## Description

Fixes bug by doing sanity checks to make sure it's array that's passed on.

## Motivation and Context

> `Uncaught TypeError: Argument 1 passed to TMS\Theme\Base\Formatters\AccordionFormatter::handle_layouts() must be of the type array, bool given, called in tms-theme-base/lib/Formatters/AccordionFormatter.php on line 48 and defined in tms-theme-base/lib/Traits/Components.php:39`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING] document.
