### PR TITLE
TMS-1009: Fix Eventz fatal error for language versions

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1009: Fix error when fetching Eventz response with languages other than fi & en
+
 ## [1.54.5] - 2024-02-01
 
 - TMS-977: Add 'clear form' button to event-search

--- a/lib/ACF/DynamicEventGroup.php
+++ b/lib/ACF/DynamicEventGroup.php
@@ -286,10 +286,10 @@ class DynamicEventGroup {
 
         $cache_key = 'events-' . $name;
         $response  = wp_cache_get( $cache_key );
+        $lang_key  = Localization::get_current_language();
 
-        if ( ! $response ) {
+        if ( ! $response && ( $lang_key === 'fi' || $lang_key === 'en' ) ) {
             try {
-                $lang_key = Localization::get_current_language();
                 $client   = new EventzClient( PIRKANMAA_EVENTZ_API_URL, PIRKANMAA_EVENTZ_API_KEY );
                 $response = $client->{'get_' . $name }( $lang_key );
 

--- a/lib/ACF/DynamicEventGroup.php
+++ b/lib/ACF/DynamicEventGroup.php
@@ -284,11 +284,18 @@ class DynamicEventGroup {
             return $field;
         }
 
-        $cache_key = 'events-' . $name;
-        $response  = wp_cache_get( $cache_key );
-        $lang_key  = Localization::get_current_language();
+        $cache_key             = 'events-' . $name;
+        $response              = wp_cache_get( $cache_key );
+        $lang_key              = Localization::get_current_language();
+        $request_allowed_langs = [
+            'fi',
+            'en',
+        ];
 
-        if ( ! $response && ( $lang_key === 'fi' || $lang_key === 'en' ) ) {
+        if (
+            ! $response &&
+            in_array( $lang_key, $request_allowed_langs, true )
+        ) {
             try {
                 $client   = new EventzClient( PIRKANMAA_EVENTZ_API_URL, PIRKANMAA_EVENTZ_API_KEY );
                 $response = $client->{'get_' . $name }( $lang_key );


### PR DESCRIPTION
Severa-ID: 2247
Severa-kuvaus: TMS-1009 Muumimuseo.fi Liput ja aukioloajat ruotsinkielistä sivua ei pääse päivittämään
Task: https://hiondigital.atlassian.net/browse/TMS-1009

## Description
Add an if-statement for fi & en languages, since Eventz throws an error with other languages.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)