### PR TITLE
TMS-1018: Remove external-link icons from imported news image links

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1018: Remove external-link icons from imported news image links
+
 ## [1.54.5] - 2024-02-01
 
 - TMS-977: Add 'clear form' button to event-search

--- a/assets/scripts/external-links.js
+++ b/assets/scripts/external-links.js
@@ -30,7 +30,7 @@ export default class ExternalLinks {
         };
 
         // Links in regular context
-        $( '#main-content a[href*="//"]:not(.button, .logo-wall__link, .link-list a, [href*="' + domain + '"])' ).append( icon ); // eslint-disable-line
+        $( '#main-content a[href*="//"]:not(.figure__link, .button, .logo-wall__link, .link-list a, [href*="' + domain + '"])' ).append( icon ); // eslint-disable-line
 
         // Links with icons (replace current icon with "opens in new window" -icon)
         $( '#main-content a[href*="//"]:has(.icon):not(.link-list a, [href*="' + domain + '"])' ).each( function() {


### PR DESCRIPTION
Severa-ID: 2247
Severa-kuvaus: TMS-1018 Drupalista tulevan uutisen sisältöosan kuvapaikan yhteydessä turhia linkkinuoli-ikoneja ++kuvatekstin asemoinnista
Task: https://hiondigital.atlassian.net/browse/TMS-1018

## Description
Remove external-link icons from imported news image links

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

