### PR TITLE
TMS-1031: Fix event-component recurring manual-event dates

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1031: Fix event-component recurring manual-event dates
+
 ## [1.54.7] - 2024-03-26
 
 - TMS-914:

--- a/lib/Formatters/EventzFormatter.php
+++ b/lib/Formatters/EventzFormatter.php
@@ -399,14 +399,14 @@ class EventzFormatter implements \TMS\Theme\Base\Interfaces\Formatter {
 
         // Loop through events
         $recurring_events = array_map( function ( $e ) {
-            $id    = $e->ID;
-            $event = (object) \get_fields( $id );
+            $id       = $e->ID;
+            $event    = (object) \get_fields( $id );
+            $time_now = \current_datetime();
+            $timezone = new \DateTimeZone( 'Europe/Helsinki' );
 
             foreach ( $event->dates as $date ) {
-                date_default_timezone_set( 'Europe/Helsinki' );
-                $time_now    = \current_datetime()->getTimestamp();
-                $event_start = strtotime( $date['start'] );
-                $event_end   = strtotime( $date['end'] );
+                $event_start = new \DateTime( $date['start'], $timezone );
+                $event_end   = new \DateTime( $date['end'], $timezone );
 
                 // Return only ongoing or next upcoming event
                 if ( ( $time_now > $event_start && $time_now < $event_end ) || $time_now < $event_start ) {


### PR DESCRIPTION
Severa-ID: 2247
Severa-kuvaus: TMS-1031 Manuaaliset toistuvat tapahtumat, väärät kellonajat tapahtumanostossa
Task: https://hiondigital.atlassian.net/browse/TMS-1031

## Description
Replace strtotime with DateTime objects to prevent problems with timezone

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
