### PR TITLE
TMS-1013: Event entry fixes

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1013:
+    - Fix weekly date loop if event has multiple days in entries
+    - Sort entries date-array
+    - Fix checking for recurring event arrays
+
 ## [1.54.7] - 2024-03-26
 
 - TMS-914:

--- a/lib/Eventz.php
+++ b/lib/Eventz.php
@@ -396,10 +396,17 @@ class Eventz implements Controller {
         }
 
         foreach ( $event->event->dates as $date ) {
-            $dates[] = [
-                'date'        => self::compare_dates( $date->start, $date->end ),
-                'is_sold_out' => $date->isSoldOut,
-            ];
+            $time_now    = \current_datetime();
+            $current_end = new \DateTime( $date->end );
+            $current_end->setTimezone( new \DateTimeZone( 'Europe/Helsinki' ) );
+
+            // Don't show past dates
+            if ( $current_end >= $time_now ) {
+                $dates[] = [
+                    'date'        => self::compare_dates( $date->start, $date->end ),
+                    'is_sold_out' => $date->isSoldOut,
+                ];
+            }
         }
 
         return $dates;
@@ -431,10 +438,6 @@ class Eventz implements Controller {
             ];
         }
 
-        $start_date = \DateTime::createFromFormat(
-            'Y-m-d H:i:s',
-            date( 'Y-m-d H:i:s', strtotime( $event->event->start ) )
-        );
         $end_date   = \DateTime::createFromFormat(
             'Y-m-d H:i:s',
             date( 'Y-m-d H:i:s', strtotime( $event->event->end ) )
@@ -442,6 +445,12 @@ class Eventz implements Controller {
 
         // Loop through days and get the dates each week
         foreach ( $entry_data as $entry ) {
+            // Reset start_date each iteration
+            $start_date = \DateTime::createFromFormat(
+                'Y-m-d H:i:s',
+                date( 'Y-m-d H:i:s', strtotime( $event->event->start ) )
+            );
+
             // Check if the day of week matches the events start date
             if ( date( 'D', strtotime( $entry['day_of_week'] ) ) !== $start_date->format( 'D' ) ) {
                 $day_of_week = date( 'D', strtotime( $entry['day_of_week'] ) );
@@ -452,20 +461,31 @@ class Eventz implements Controller {
             while ( $start_date <= $end_date ) {
                 $current_start = new \DateTime( $start_date->format( 'Y-m-d' ) . ' ' . $entry['start_time'] );
                 $current_end   = new \DateTime( $start_date->format( 'Y-m-d' ) . ' ' . $entry['end_time'] );
-                $event_dates   = sprintf(
-                    '%s - %s',
-                    $current_start->format( 'j.n.Y H.i' ),
-                    $current_end->format( 'H.i' )
-                );
+                $time_now      = \current_datetime();
 
-                $entries[] = [
-                    'date'        => $event_dates,
-                    'is_sold_out' => $entry['sold_out'] ?? '',
-                ];
+                // Don't show past dates
+                if ( $current_end >= $time_now ) {
+                    $event_dates = sprintf(
+                        '%s - %s',
+                        $current_start->format( 'j.n.Y H.i' ),
+                        $current_end->format( 'H.i' )
+                    );
+
+                    $entries[] = [
+                        'date'        => $event_dates,
+                        'is_sold_out' => $entry['sold_out'] ?? '',
+                        'start_date'  => $current_start->getTimestamp(),
+                    ];
+                }
 
                 $start_date->modify( '+1 week' );
             }
         }
+
+        // Sort entry-dates by start_date timestamp
+        usort( $entries, function ($a, $b) {
+            return $a['start_date'] <=> $b['start_date'];
+        });
 
         return $entries;
     }

--- a/lib/Eventz.php
+++ b/lib/Eventz.php
@@ -431,11 +431,18 @@ class Eventz implements Controller {
             ];
         }
 
-        $start_date = \DateTime::createFromFormat( 'Y-m-d H:i:s', date( 'Y-m-d H:i:s', strtotime( $event->event->start ) ) );
-        $end_date   = \DateTime::createFromFormat( 'Y-m-d H:i:s', date( 'Y-m-d H:i:s', strtotime( $event->event->end ) ) );
+        $start_date = \DateTime::createFromFormat(
+            'Y-m-d H:i:s',
+            date( 'Y-m-d H:i:s', strtotime( $event->event->start ) )
+        );
+        $end_date   = \DateTime::createFromFormat(
+            'Y-m-d H:i:s',
+            date( 'Y-m-d H:i:s', strtotime( $event->event->end ) )
+        );
 
         // Loop through days and get the dates each week
         foreach ( $entry_data as $entry ) {
+            // Check if the day of week matches the events start date
             if ( date( 'D', strtotime( $entry['day_of_week'] ) ) !== $start_date->format( 'D' ) ) {
                 $day_of_week = date( 'D', strtotime( $entry['day_of_week'] ) );
                 $start_date->modify( "next $day_of_week" );
@@ -480,11 +487,11 @@ class Eventz implements Controller {
         $event_page = Settings::get_setting( 'events_page' );
 
         if ( $event_page ) {
-            return add_query_arg(
+            return \add_query_arg(
                 [
                     'event-id' => $event_id,
                 ],
-                get_permalink( $event_page )
+                \get_permalink( $event_page )
             );
         }
 

--- a/lib/Formatters/EventzFormatter.php
+++ b/lib/Formatters/EventzFormatter.php
@@ -110,16 +110,18 @@ class EventzFormatter implements \TMS\Theme\Base\Interfaces\Formatter {
         $recurring_events = [];
         if( ! empty( $events['events'] ) ) {
             foreach ( $events['events'] as $event ) {
+                $recurring_event_dates = [];
 
                 // Chek if event has dates or entries
-                if ( count( $event['dates'] ) > 1 ) {
+                if ( isset( $event['dates'] ) && count( $event['dates'] ) > 1 ) {
                     $recurring_event_dates = $event['dates'];
-                } else if ( ! empty( $event['entries'] ) ) {
+                }
+                elseif ( ! empty( $event['entries'] ) ) {
                     $recurring_event_dates = $event['entries'];
                 }
 
                 // Get recurring event single dates
-                if ( isset( $recurring_event_dates ) ) {
+                if ( ! empty( $recurring_event_dates ) ) {
                     foreach ( $recurring_event_dates as $date ) {
                         $clone = $event;
                         unset( $endDate );

--- a/lib/Formatters/EventzFormatter.php
+++ b/lib/Formatters/EventzFormatter.php
@@ -113,7 +113,7 @@ class EventzFormatter implements \TMS\Theme\Base\Interfaces\Formatter {
                 $recurring_event_dates = [];
 
                 // Chek if event has dates or entries
-                if ( isset( $event['dates'] ) && count( $event['dates'] ) > 1 ) {
+                if ( isset( $event['dates'] ) && count( $event['dates'] ) >= 1 ) {
                     $recurring_event_dates = $event['dates'];
                 }
                 elseif ( ! empty( $event['entries'] ) ) {


### PR DESCRIPTION
Severa-ID: 2247
Severa-kuvaus: CSD-838 Useiden integroitujen tapahtumien tapahtuma-ajat vääriä wp-sivustolla
Task: https://hiondigital.atlassian.net/browse/CSD-838
(original task TMS-1013)

## Description
Additions:
- Hide past dates in single event page

Fixes:
- Eventz.php
    - Fix weekly date loop if event has multiple days in entries
    - Sort entry date-array
- EventzFormatter.php
    - Fix checking for recurring event arrays

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
