### PR TITLE
TMS-1055: Fix mailto-links escaping-filter

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1055: Fix mailto-links escaping-filter
+
 ## [1.56.0] - 2024-06-12
 
 - TMS-1050: Add if-statements into accordion script to prevent breaking other elements functionality

--- a/partials/shared/contact-item.dust
+++ b/partials/shared/contact-item.dust
@@ -54,7 +54,7 @@
                     {>"ui/icon" icon="email" class="icon--large is-primary" /}
                 </div>
 
-                <a href="mailto:{email|url}" class="has-text-paragraph hyphenate">
+                <a href="mailto:{email|attr}" class="has-text-paragraph hyphenate">
                     {email|html}
                 </a>
             </div>


### PR DESCRIPTION
Severa-ID: 2247
Severa-kuvaus: TMS-1055 Yhteystietojen mailto-linkki ei toimi
Task: https://hiondigital.atlassian.net/browse/TMS-1055


## Description
Fix mailto-links escaping-filter

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

