### PR TITLE
TMS-1075-fix: Early return added to ImageGalleryFormatter

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1075-fix: Early return added to ImageGalleryFormatter
+
 ## [1.59.0] - 2024-10-24
 
 - TMS-1075: Redipress 2 filters

--- a/lib/Formatters/ImageGalleryFormatter.php
+++ b/lib/Formatters/ImageGalleryFormatter.php
@@ -35,6 +35,10 @@ class ImageGalleryFormatter implements \TMS\Theme\Base\Interfaces\Formatter {
      * @return array
      */
     public function format( array $data ) : array {
+        if ( empty( $data['rows'] ) ) {
+            return $data;
+        }
+
         $data['rows'] = array_map( static function ( $item ) {
             $item = \TMS\Theme\Base\Formatters\ImageFormatter::format( $item );
 


### PR DESCRIPTION
Severa-ID: 2108
Severa-kuvaus: TMS-1075 Redipress 2 päivitys
Task: https://hiondigital.atlassian.net/browse/TMS-1075

## Description
Add an early return to prevent fatal error while indexing posts

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)