### PR TITLE
TMS-1089: Fix event fetching for events-component

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1089: Fix event fetching for events-component
+
 ## [1.59.3] - 2024-11-25
 
 - TMS-1059: Eventz changes:

--- a/lib/Formatters/EventzFormatter.php
+++ b/lib/Formatters/EventzFormatter.php
@@ -87,11 +87,11 @@ class EventzFormatter implements \TMS\Theme\Base\Interfaces\Formatter {
 
         $layout['events']  = $this->format_events( $events, $layout['show_images'] );
         $layout['classes'] = [
-            'event_item_bg'   => apply_filters( 'tms/theme/layout_events/item_bg_class', 'has-background-secondary' ),
-            'event_item_text' => apply_filters( 'tms/theme/layout_events/item_text_class', '' ),
-            'event_item_icon' => apply_filters( 'tms/theme/layout_events/item_icon_class', '' ),
-            'all_events_link' => apply_filters( 'tms/theme/layout_events/all_events_link', 'is-size-7' ),
-            'event_item_pill' => apply_filters( 'tms/theme/layout_events/event_item', 'is-primary-invert' ),
+            'event_item_bg'   => \apply_filters( 'tms/theme/layout_events/item_bg_class', 'has-background-secondary' ),
+            'event_item_text' => \apply_filters( 'tms/theme/layout_events/item_text_class', '' ),
+            'event_item_icon' => \apply_filters( 'tms/theme/layout_events/item_icon_class', '' ),
+            'all_events_link' => \apply_filters( 'tms/theme/layout_events/all_events_link', 'is-size-7' ),
+            'event_item_pill' => \apply_filters( 'tms/theme/layout_events/event_item', 'is-primary-invert' ),
         ];
 
         return $layout;
@@ -106,10 +106,10 @@ class EventzFormatter implements \TMS\Theme\Base\Interfaces\Formatter {
      *
      * @return void
      */
-    public static function create_recurring_events( $events, $query_params )  {
+    public static function create_recurring_events( $events, $query_params ) {
 
         $recurring_events = [];
-        if( ! empty( $events['events'] ) ) {
+        if ( ! empty( $events['events'] ) ) {
             foreach ( $events['events'] as $event ) {
                 $recurring_event_dates = [];
 
@@ -143,7 +143,7 @@ class EventzFormatter implements \TMS\Theme\Base\Interfaces\Formatter {
                         }
 
                         // Check if endPart includes date & time
-                        if ( strpos($endPart, ' ') ) {
+                        if ( strpos( $endPart, ' ' ) ) {
                             list( $endDate, $endTime ) = explode( ' ', $endPart, 2 );
                         }
                         else {
@@ -185,7 +185,8 @@ class EventzFormatter implements \TMS\Theme\Base\Interfaces\Formatter {
 
                         $recurring_events[] = $clone;
                     }
-                } else {
+                }
+                else {
                     $recurring_events[] = $event;
                 }
             }
@@ -248,7 +249,6 @@ class EventzFormatter implements \TMS\Theme\Base\Interfaces\Formatter {
             'sort'        => null,
             'size'        => null,
             'skip'        => null,
-            'page_size'   => null,
         ];
 
         foreach ( $layout as $key => $value ) {
@@ -287,13 +287,12 @@ class EventzFormatter implements \TMS\Theme\Base\Interfaces\Formatter {
      *
      * @return array|null
      */
-    private function get_events( array $query_params ) : ?array {
+    private function get_events( array $query_params ): ?array {
         // Force sort param
         $query_params['sort'] = 'startDate';
 
-        if ( ! empty( $query_params['page_size'] ) ) {
-            $query_params['size'] = $query_params['page_size'];
-        }
+        // Get enough events to show correct events if they're recurring
+        $query_params['size'] = 30;
 
         $client = new EventzClient( PIRKANMAA_EVENTZ_API_URL, PIRKANMAA_EVENTZ_API_KEY );
 

--- a/models/page-events-calendar.php
+++ b/models/page-events-calendar.php
@@ -26,7 +26,7 @@ class PageEventsCalendar extends PageEventsSearch {
     /**
      * Description text
      */
-    public function description() : ?string {
+    public function description(): ?string {
         return get_field( 'description' );
     }
 
@@ -35,7 +35,7 @@ class PageEventsCalendar extends PageEventsSearch {
      *
      * @return string
      */
-    public function no_results() : string {
+    public function no_results(): string {
         return __( 'No results', 'tms-theme-base' );
     }
 
@@ -44,7 +44,7 @@ class PageEventsCalendar extends PageEventsSearch {
      *
      * @return bool
      */
-    public function is_grid() : bool {
+    public function is_grid(): bool {
         $is_grid = get_field( 'layout' ) ?? 'grid';
 
         return $is_grid === 'grid';
@@ -55,7 +55,7 @@ class PageEventsCalendar extends PageEventsSearch {
      *
      * @return string
      */
-    public function item_partial() : string {
+    public function item_partial(): string {
         $part = $this->is_grid() ? 'grid' : 'list';
 
         return 'views/page-events-calendar/page-events-calendar-item-' . $part;
@@ -64,7 +64,7 @@ class PageEventsCalendar extends PageEventsSearch {
     /**
      * Get events
      */
-    public function events() : ?array {
+    public function events(): ?array {
         try {
             $response = $this->get_events();
 
@@ -82,28 +82,28 @@ class PageEventsCalendar extends PageEventsSearch {
      *
      * @return array
      */
-    protected function get_events() : array {
+    protected function get_events(): array {
 
-        $paged = get_query_var( 'paged', 1 );
+        $paged = \get_query_var( 'paged', 1 );
         $skip  = 0;
 
         if ( $paged > 1 ) {
-            $skip = ( $paged - 1 ) * get_option( 'posts_per_page' );
+            $skip = ( $paged - 1 ) * \get_option( 'posts_per_page' );
         }
 
         $params = [
-            'q'           => get_field( 'text' ),
-            'start'       => get_field( 'start' ),
-            'end'         => get_field( 'end' ),
-            'category_id' => get_field( 'category' ),
-            'areas'       => get_field( 'area' ),
-            'targets'     => get_field( 'target' ),
-            'tags'        => get_field( 'tag' ),
+            'q'           => \get_field( 'text' ),
+            'start'       => \get_field( 'start' ),
+            'end'         => \get_field( 'end' ),
+            'category_id' => \get_field( 'category' ),
+            'areas'       => \get_field( 'area' ),
+            'targets'     => \get_field( 'target' ),
+            'tags'        => \get_field( 'tag' ),
             'sort'        => 'startDate',
-            'show_images' => get_field( 'show_images' ),
+            'show_images' => \get_field( 'show_images' ),
         ];
 
-        if ( ! empty( get_field( 'starts_today' ) ) && true === get_field( 'starts_today' ) ) {
+        if ( ! empty( \get_field( 'starts_today' ) ) && true === \get_field( 'starts_today' ) ) {
             $params['start'] = date( 'Y-m-d' );
         }
 
@@ -116,15 +116,15 @@ class PageEventsCalendar extends PageEventsSearch {
         $params    = $formatter->format_query_params( $params );
 
         $cache_group = 'page-events-calendar';
-        $cache_key   = md5( wp_json_encode( $params ) );
-        $response    = wp_cache_get( $cache_key, $cache_group );
+        $cache_key   = md5( \wp_json_encode( $params ) );
+        $response    = \wp_cache_get( $cache_key, $cache_group );
 
         if ( empty( $response ) ) {
 
             $response = $this->do_get_events( $params );
 
             if ( ! empty( $response ) ) {
-                wp_cache_set(
+                \wp_cache_set(
                     $cache_key,
                     $response,
                     $cache_group,
@@ -136,7 +136,7 @@ class PageEventsCalendar extends PageEventsSearch {
         if ( ! empty( $response['events'] ) ) {
 
             // Sort events.
-            usort( $response['events'], function( $a, $b ) {
+            usort( $response['events'], function ( $a, $b ) {
                 return $a['start_date_raw'] <=> $b['start_date_raw'];
             } );
 
@@ -153,7 +153,7 @@ class PageEventsCalendar extends PageEventsSearch {
      *
      * @return array|null
      */
-    public function calendar_pages() : ?array {
+    public function calendar_pages(): ?array {
         if ( ! Settings::get_setting( 'show_related_events_calendars' ) ) {
             return null;
         }
@@ -171,7 +171,7 @@ class PageEventsCalendar extends PageEventsSearch {
             return null;
         }
 
-        $current_page = get_queried_object_id();
+        $current_page = \get_queried_object_id();
 
         $pages = array_filter( $the_query->posts, function ( $item ) use ( $current_page ) {
             return $item->ID !== $current_page;
@@ -179,7 +179,7 @@ class PageEventsCalendar extends PageEventsSearch {
 
         return array_map( function ( $item ) {
             return [
-                'url'   => get_the_permalink( $item->ID ),
+                'url'   => \get_the_permalink( $item->ID ),
                 'title' => $item->post_title,
             ];
         }, $pages );


### PR DESCRIPTION
Severa-ID: 2247
Severa-kuvaus: TMS-1089 Muumimuseon viikkokalenteritapahtumat eivät näy etusivulla
Task: https://hiondigital.atlassian.net/browse/TMS-1089

## Description
Fix event fetching for events-component.

The previous code was fetching the specific amount of events that are selected to be shown on the component, which caused it to show wrong events, since some recurring events weren't fetched. Recurring events are handled after the initial fetch from the API.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
