### PR TITLE
TMS-1109: Change ContentColumns & CallToAction TextArea fields to Wysiwyg

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1109: Change ContentColumns & CallToAction TextArea fields to Wysiwyg
+
 ## [1.59.7] - 2025-02-24
 
 - TMS-1100: Show multiple locations for events if available

--- a/lib/ACF/Fields/CallToActionFields.php
+++ b/lib/ACF/Fields/CallToActionFields.php
@@ -105,11 +105,11 @@ class CallToActionFields extends Field\Group {
             ->redipress_include_search()
             ->set_instructions( $strings['title']['instructions'] );
 
-        $description_field = ( new Field\Textarea( $strings['description']['label'] ) )
+        $description_field = ( new Field\Wysiwyg( $strings['description']['label'] ) )
             ->set_key( "{$key}_description" )
             ->set_name( 'description' )
-            ->set_rows( 4 )
-            ->set_new_lines( 'wpautop' )
+            ->set_toolbar( [ 'bold', 'italic' ] )
+            ->disable_media_upload()
             ->set_wrapper_width( 50 )
             ->redipress_include_search()
             ->set_instructions( $strings['description']['instructions'] );

--- a/lib/ACF/Fields/ContentColumnsFields.php
+++ b/lib/ACF/Fields/ContentColumnsFields.php
@@ -105,11 +105,11 @@ class ContentColumnsFields extends Field\Group {
             ->set_wrapper_width( 45 )
             ->set_instructions( $strings['image']['instructions'] );
 
-        $description_field = ( new Field\Textarea( $strings['description']['label'] ) )
+        $description_field = ( new Field\Wysiwyg( $strings['description']['label'] ) )
             ->set_key( "{$key}_description" )
             ->set_name( 'description' )
-            ->set_rows( 4 )
-            ->set_new_lines( 'wpautop' )
+            ->set_toolbar( [ 'bold', 'italic' ] )
+            ->disable_media_upload()
             ->set_wrapper_width( 55 )
             ->redipress_include_search()
             ->set_instructions( $strings['description']['instructions'] );


### PR DESCRIPTION
Severa-ID: 2108
Severa-kuvaus: TMS-1109 Lihavointi ja kursivointi mahdolliseksi kolmeen komponenttiin
Task: https://hiondigital.atlassian.net/browse/TMS-TMS-1109

## Description
Change content-columns (Palstat) & call-to-action (Manuaaliset nostot) components TextAreas to Wysiwyg-fields

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
