### PR TITLE
TMS-1183: Use Logger for EventzClient errors

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1183: Use Logger for EventzClient errors
+
 ## [1.62.0] - 2025-06-23
 
 - TMS-1172: Add video possibility to hero-museum layout

--- a/lib/EventzClient.php
+++ b/lib/EventzClient.php
@@ -316,10 +316,12 @@ class EventzClient {
         $status_code = $payload->status_code;
 
         if ( ! in_array( $status_code, [ 200, 201 ], true ) ) {
-            throw new EventzException(
+            ( new Logger() )->error(
                 sprintf( '%s: %s', $api_url, $payload->body ?? 'Unknown error' ),
-                $status_code
+                [ 'status_code' => $status_code ]
             );
+
+            return false;
         }
 
         return $payload->body ?? '';


### PR DESCRIPTION
Severa-ID: 2247
Severa-kuvaus: TMS-1183 Eventz-integraation korjaus puuttuvan API-avaimen osalta
Task: https://hiondigital.atlassian.net/browse/TMS-1183

## Description
Log error instead of throwing the exception which causes a fatal error in wp-admin

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

