### PR TITLE
TMS-1158: Remove micromodal close attribute from mobile-nav container

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1158: Disable mobile-nav from closing when scrolling by clicking the inner container
+
 ## [1.62.0] - 2025-06-23
 
 - TMS-1172: Add video possibility to hero-museum layout

--- a/assets/scripts/header.js
+++ b/assets/scripts/header.js
@@ -64,11 +64,6 @@ export default class Header {
         $( '.fly-out-nav__close' ).on( 'click', this.closeFlyOutMenu.bind( this ) );
         $( '.fly-out-nav .js-scroll-children' ).on( 'click', this.closeFlyOutMenu.bind( this ) );
 
-        // Prevent closing the menu when clicking inside the fly-out nav.
-        $( '.fly-out-nav__inner' ).on( 'click', ( event ) => {
-            event.stopPropagation();
-        } );
-
         MicroModal.init( {
             disableScroll: true,
             onShow: this.onFlyOutMenuOpen.bind( this ),

--- a/assets/scripts/header.js
+++ b/assets/scripts/header.js
@@ -64,6 +64,11 @@ export default class Header {
         $( '.fly-out-nav__close' ).on( 'click', this.closeFlyOutMenu.bind( this ) );
         $( '.fly-out-nav .js-scroll-children' ).on( 'click', this.closeFlyOutMenu.bind( this ) );
 
+        // Prevent closing the menu when clicking inside the fly-out nav.
+        $( '.fly-out-nav__inner' ).on( 'click', ( event ) => {
+            event.stopPropagation();
+        } );
+
         MicroModal.init( {
             disableScroll: true,
             onShow: this.onFlyOutMenuOpen.bind( this ),

--- a/partials/ui/menu/fly-out-nav.dust
+++ b/partials/ui/menu/fly-out-nav.dust
@@ -1,5 +1,5 @@
 <nav id="js-fly-out-nav" class="fly-out-nav overlay overlay--dark-80" aria-hidden="true">
-    <div class="is-overlay" tabindex="-1" data-micromodal-close>
+    <div class="is-overlay" tabindex="-1">
         <div class="fly-out-nav__inner {Header.colors.fly_out_nav.inner|attr}" role="dialog" aria-modal="true">
             <button class="fly-out-nav__close">
                 <span class="is-sr-only"> {Strings.s.header.close_menu|html} </span>


### PR DESCRIPTION
Severa-ID: 2247
Severa-kuvaus: TMS-1158 Saavutettavuus: Päävalikon ja lomakkeen responsiivisuus
Task: https://hiondigital.atlassian.net/browse/TMS-1158

## Description
Remove modal close attribute to prevent mobile nav closing when the user taps on the container when attempting to scroll down

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
