### PR TITLE
TMS-1264: Fix Eventz to use endpoint url from env

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1264: Fix Eventz to use endpoint url from env
+
 ## [1.71.3] - 2026-03-16
 
 - TMS-1259: Disable link underline in theme.json

--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -74,7 +74,7 @@ class Constants implements Interfaces\Controller {
         }
 
         if ( ! defined( 'PIRKANMAA_EVENTZ_API_URL' ) ) {
-            define( 'PIRKANMAA_EVENTZ_API_URL', 'https://backend.ver5.eventz.today/' );
+            define( 'PIRKANMAA_EVENTZ_API_URL', env( 'PIRKANMAA_EVENTZ_API_URL' ) ?? '' );
         }
 
         if ( ! defined( 'PIRKANMAA_EVENTZ_API_KEY' ) ) {


### PR DESCRIPTION
Project: Tampereen kaupunki, konsernihallinto / Tietohallintoyksikkö:
Project task: Tampere multisite support

Task: https://hiondigital.atlassian.net/browse/TMS-1264
Task title: Tapahtumasivu ei avaudu, useita sivustoja

## Description
Use Eventz endpoint from env, remove hardcoded old endpoint url

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
