### PR TITLE
Remove deprecated utf8_encode() from the pwned-password check

### DIFF
--- a/lib/Security.php
+++ b/lib/Security.php
@@ -38,7 +38,7 @@ class Security implements Interfaces\Controller {
      * @return bool
      */
     public static function check_password_pwnd_status( string $password ) {
-        $password_hash = utf8_encode( strtoupper( sha1( $password ) ) );
+        $password_hash = strtoupper( sha1( $password ) );
         $k_anon        = substr( $password_hash, 0, 5 );
 
         $service_url = 'https://api.pwnedpasswords.com/range/' . $k_anon;


### PR DESCRIPTION
PHP 8.2 housekeeping. `Security::check_password_pwnd_status()` wraps its hash in `utf8_encode()`, which is deprecated as of PHP 8.2. Here the argument is `strtoupper( sha1( $password ) )`, which is always a pure-ASCII hex string, so `utf8_encode()` returns it unchanged and the call is a no-op.

Dropping it removes the deprecation notice with no change to `$password_hash` or the downstream HIBP range lookup. I went with removing it rather than swapping in `mb_convert_encoding()`, since there's nothing to convert. Happy to use the wrapper instead if you'd prefer.

Clean codebase to work in, thanks for open-sourcing the theme base.

(full disclosure: AI helped me spot this; the change and this note are mine.)
